### PR TITLE
Add failed url to 404 handling as tag

### DIFF
--- a/Classes/ErrorHandlers/SentryPageNotFoundHandler.php
+++ b/Classes/ErrorHandlers/SentryPageNotFoundHandler.php
@@ -15,8 +15,8 @@ class SentryPageNotFoundHandler {
     public function handle($params, $tsfe) {
         $ravenClient = $GLOBALS['SENTRY_CLIENT'] ?? null;
 
-        if($ravenClient) {
-            $ravenClient->message('404 Page not found', [], Raven_Client::WARNING, false, $params);
+        if($ravenClient instanceof Raven_Client) {
+            $ravenClient->captureMessage('404 Page not found', [], ['level' => Raven_Client::WARNING, 'tags' => ['failedUrl' => $params['currentUrl']]], false, $params);
         }
 
         $tsfe->pageErrorHandler($GLOBALS['TYPO3_CONF_VARS']['FE']['pageNotFound_handling_original']);


### PR DESCRIPTION
Do not use deprecated method Raven_Client::capture but captureMessage and add the
failed url as a tag so items can be grouped or filtered by the failed url.