### PR TITLE
Log 404 as INFO and put the url and reason to the title

### DIFF
--- a/Classes/ErrorHandlers/SentryPageNotFoundHandler.php
+++ b/Classes/ErrorHandlers/SentryPageNotFoundHandler.php
@@ -16,7 +16,13 @@ class SentryPageNotFoundHandler {
         $ravenClient = $GLOBALS['SENTRY_CLIENT'] ?? null;
 
         if($ravenClient instanceof Raven_Client) {
-            $ravenClient->captureMessage('404 Page not found', [], ['level' => Raven_Client::WARNING, 'tags' => ['failedUrl' => $params['currentUrl']]], false, $params);
+            $ravenClient->captureMessage(
+                '404 Page not found (%s): %s',
+                [$params['currentUrl'], $params['reasonText']],
+                ['level' => Raven_Client::INFO, 'tags' => ['failedUrl' => $params['currentUrl']]],
+                false,
+                $params
+            );
         }
 
         $tsfe->pageErrorHandler($GLOBALS['TYPO3_CONF_VARS']['FE']['pageNotFound_handling_original']);


### PR DESCRIPTION
Sentry groups all events by the title. So it is not possible to close or ignore just
some errors for specific urls but only all 404 error. Thats why the url has been added
to the title. Now every 404 should create a new error but not only an event for a 404.
As all of those informations are informations and not really warnings the level has been
adjusted to INFO.